### PR TITLE
GET posts에서 username이 undefined여도 반환되도록 수정

### DIFF
--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -87,7 +87,7 @@ export class PostsService {
       id: post._id.toString(),
       title: post.title,
       content: post.content,
-      author: post.author['username'],
+      author: post.author?.['username'],
       categories: post.categories.map((category) => category.toString()),
       likes: post.likes,
       createdAt: post.createdAt,


### PR DESCRIPTION
# 문제발견
GET posts API 호출 시, 500 Internal Server Error가 발생했습니다.

# 원인분석
post 테이블에서 Author의 값이 null인 경우를 발견했습니다.

# 해결
posts에서 author값이 null일 경우를 생각해서, 옵셔널 체이닝으로 처리했습니다.