### PR TITLE
post 최신 작성일이 앞으로 오도록 수정

### DIFF
--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -106,6 +106,7 @@ export class PostsService {
       {
         $unwind: '$authorDetails',
       },
+      { $sort: { createdAt: -1 } },
       {
         $project: {
           title: 1,


### PR DESCRIPTION
# 문제발견
post들을 불러올때 오래된 포스트가 먼저 반환됐습니다.

# 원인분석
정렬을 따로 설정하지 않으면, 오래된 순서부터 반환되도록 되어 있습니다.

# 해결 
createdAt을 기준으로 내림차순(최신 순)으로 정렬을 추가하였습니다.